### PR TITLE
Adapt PSPs to GiantSwarm policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Adapt PSPs to GiantSwarm policies.
+
 ## [0.3.0] - 2022-07-15
 
 ### Added

--- a/config/helm/csi-gce-pd-controller-psp.yaml
+++ b/config/helm/csi-gce-pd-controller-psp.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: csi-gce-pd-controller-psp
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+      - max: 65535
+        min: 1
+    rule: MustRunAs
+  runAsUser:
+    ranges:
+      - max: 65535
+        min: 1000
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+    - min: 22010
+      max: 22015
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+      - max: 65535
+        min: 1
+    rule: MustRunAs
+  volumes:
+    - secret
+    - configMap
+    - emptyDir

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -32,3 +32,4 @@ transformers:
 patchesStrategicMerge:
   - delete-windows.yaml
   - delete-credentials.yaml
+  - csi-gce-pd-controller-psp.yaml

--- a/config/helm/storage-classes.yaml
+++ b/config/helm/storage-classes.yaml
@@ -5,18 +5,18 @@ metadata:
   name: standard
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
-provisioner: kubernetes.io/gce-pd
+provisioner: pd.csi.storage.gke.io
 parameters:
   type: pd-balanced
-  fstype: ext4
+  csi.storage.k8s.io/fstype: ext4
 volumeBindingMode: WaitForFirstConsumer
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: ssd
-provisioner: kubernetes.io/gce-pd
+provisioner: pd.csi.storage.gke.io
 parameters:
   type: pd-ssd
-  fstype: ext4
+  csi.storage.k8s.io/fstype: ext4
 volumeBindingMode: WaitForFirstConsumer

--- a/helm/gcp-compute-persistent-disk-csi-driver/templates/policy_v1beta1_podsecuritypolicy_csi-gce-pd-controller-psp.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/templates/policy_v1beta1_podsecuritypolicy_csi-gce-pd-controller-psp.yaml
@@ -11,15 +11,29 @@ metadata:
     helm.sh/chart: gcp-compute-persistent-disk-csi-driver
   name: csi-gce-pd-controller-psp
 spec:
+  allowPrivilegeEscalation: false
   fsGroup:
-    rule: RunAsAny
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
   hostNetwork: true
+  hostPorts:
+  - max: 22015
+    min: 22010
   runAsUser:
-    rule: RunAsAny
+    ranges:
+    - max: 65535
+      min: 1000
+    rule: MustRunAs
   seLinux:
     rule: RunAsAny
   supplementalGroups:
-    rule: RunAsAny
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
   volumes:
-  - emptyDir
   - secret
+  - configMap
+  - emptyDir

--- a/helm/gcp-compute-persistent-disk-csi-driver/templates/storage.k8s.io_v1_storageclass_ssd.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/templates/storage.k8s.io_v1_storageclass_ssd.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: gcp-compute-persistent-disk-csi-driver
   name: ssd
 parameters:
-  fstype: ext4
+  csi.storage.k8s.io/fstype: ext4
   type: pd-ssd
-provisioner: kubernetes.io/gce-pd
+provisioner: pd.csi.storage.gke.io
 volumeBindingMode: WaitForFirstConsumer

--- a/helm/gcp-compute-persistent-disk-csi-driver/templates/storage.k8s.io_v1_storageclass_standard.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/templates/storage.k8s.io_v1_storageclass_standard.yaml
@@ -13,7 +13,7 @@ metadata:
     helm.sh/chart: gcp-compute-persistent-disk-csi-driver
   name: standard
 parameters:
-  fstype: ext4
+  csi.storage.k8s.io/fstype: ext4
   type: pd-balanced
-provisioner: kubernetes.io/gce-pd
+provisioner: pd.csi.storage.gke.io
 volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
We need to adapt PSP's to fix

```
Error creating: pods "csi-gce-pd-controller-c6f678d6f-" is forbidden: PodSecurityPolicy: unable to admit pod: [spec.containers[1].hostPort: Invalid value: 22011: Host port 22011 is not allowed to be used. Allowed ports: [] spec.containers[2].hostPort: Invalid value: 22012: Host port 22012 is not allowed to be used. Allowed ports: [] spec.containers[3].hostPort: Invalid value: 22013: Host port 22013 is not allowed to be used. Allowed ports: [] spec.securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used spec.containers[1].hostPort: Invalid value: 22011: Host port 22011 is not allowed to be used. Allowed ports: [] spec.containers[2].hostPort: Invalid value: 22012: Host port 22012 is not allowed to be used. Allowed ports: [] spec.containers[3].hostPort: Invalid value: 22013: Host port 22013 is not allowed to be used. Allowed ports: [] spec.containers[1].hostPort: Invalid value: 22011: Host port 22011 is not allowed to be used. Allowed ports: [] spec.containers[2].hostPort: Invalid value: 22012: Host port 22012 is not allowed to be used. Allowed ports: [] spec.containers[3].hostPort: Invalid value: 22013: Host port 22013 is not allowed to be used. Allowed ports: []]
```
