### PR TITLE
Configure workload identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 - Allow `projected` volume type in controller PSP, needed for for workload identity
-- Use `7a126c25-gs1` image tag. This image contains necessary dependency updates for workload identity
 
 ## [0.4.0] - 2022-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- `giantswarm.io/gcp-workload-identity-pool-id` and `giantswarm.io/gcp-identity-provider` annotations and helm values
+
+## Fixed
+
+- Allow `projected` volume type in controller PSP, needed for for workload identity
+- Use `7a126c25-gs1` image tag. This image contains necessary dependency updates for workload identity
+
 ## [0.4.0] - 2022-07-19
 
 ### Fixed

--- a/config/helm/csi-gce-pd-controller-psp.yaml
+++ b/config/helm/csi-gce-pd-controller-psp.yaml
@@ -30,3 +30,4 @@ spec:
     - secret
     - configMap
     - emptyDir
+    - projected

--- a/helm/gcp-compute-persistent-disk-csi-driver/templates/apps_v1_deployment_csi-gce-pd-controller.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/templates/apps_v1_deployment_csi-gce-pd-controller.yaml
@@ -16,7 +16,6 @@ spec:
   selector:
     matchLabels:
       app: gcp-compute-persistent-disk-csi-driver
-      giantswarm.io/gcp-workload-identity: enabled
   template:
     metadata:
       labels:

--- a/helm/gcp-compute-persistent-disk-csi-driver/templates/policy_v1beta1_podsecuritypolicy_csi-gce-pd-controller-psp.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/templates/policy_v1beta1_podsecuritypolicy_csi-gce-pd-controller-psp.yaml
@@ -37,3 +37,4 @@ spec:
   - secret
   - configMap
   - emptyDir
+  - projected

--- a/helm/gcp-compute-persistent-disk-csi-driver/templates/v1_serviceaccount_csi-gce-pd-controller-sa.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/templates/v1_serviceaccount_csi-gce-pd-controller-sa.yaml
@@ -2,9 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    giantswarm.io/gcp-workload-identity-pool-id: '{{.Values.gcpWorkloadIdentityPoolID}}'
-    giantswarm.io/gcp-identity-provider: '{{.Values.gcpIdentityProvider}}'
-    giantswarm.io/gcp-service-account: '{{.Values.gcpServiceAccount}}'
+    giantswarm.io/gcp-service-account: '{{ .Values.clusterID }}-gcp-compute-persistent-d@{{ .Values.gcpProject }}.iam.gserviceaccount.com'
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/gcp-compute-persistent-disk-csi-driver/templates/v1_serviceaccount_csi-gce-pd-controller-sa.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/templates/v1_serviceaccount_csi-gce-pd-controller-sa.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    giantswarm.io/gcp-service-account: '{{ .Values.clusterID }}-gcp-compute-persistent-d@{{ .Values.gcpProject }}.iam.gserviceaccount.com'
+    giantswarm.io/gcp-service-account: 'gcp-compute-persistent-disk-cs@{{ .Values.gcpProject }}.iam.gserviceaccount.com'
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/gcp-compute-persistent-disk-csi-driver/templates/v1_serviceaccount_csi-gce-pd-controller-sa.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/templates/v1_serviceaccount_csi-gce-pd-controller-sa.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    giantswarm.io/gcp-workload-identity-pool-id: '{{.Values.gcpProject}}.svc.id.goog'
-    giantswarm.io/gcp-identity-provider: 'https://gkehub.googleapis.com/projects/{{.Values.gcpProject}}/locations/global/memberships/{{.Values.gkeHubMembershiName}}'
+    giantswarm.io/gcp-workload-identity-pool-id: '{{.Values.workloadIdentityPoolID}}'
+    giantswarm.io/gcp-identity-provider: '{{.Values.gcpIdentityProvider}}'
     giantswarm.io/gcp-service-account: '{{.Values.gcpServiceAccount}}'
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'

--- a/helm/gcp-compute-persistent-disk-csi-driver/templates/v1_serviceaccount_csi-gce-pd-controller-sa.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/templates/v1_serviceaccount_csi-gce-pd-controller-sa.yaml
@@ -3,6 +3,8 @@ kind: ServiceAccount
 metadata:
   annotations:
     giantswarm.io/gcp-workload-identity-pool-id: '{{.Values.gcpProject}}.svc.id.goog'
+    giantswarm.io/gcp-identity-provider: 'https://gkehub.googleapis.com/projects/{{.Values.gcpProject}}/locations/global/memberships/{{.Values.gkeHubMembershiName}}'
+    giantswarm.io/gcp-service-account: '{{.Values.gcpServiceAccount}}'
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/gcp-compute-persistent-disk-csi-driver/templates/v1_serviceaccount_csi-gce-pd-controller-sa.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/templates/v1_serviceaccount_csi-gce-pd-controller-sa.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    giantswarm.io/gcp-workload-identity-pool-id: '{{.Values.workloadIdentityPoolID}}'
+    giantswarm.io/gcp-workload-identity-pool-id: '{{.Values.gcpWorkloadIdentityPoolID}}'
     giantswarm.io/gcp-identity-provider: '{{.Values.gcpIdentityProvider}}'
     giantswarm.io/gcp-service-account: '{{.Values.gcpServiceAccount}}'
   labels:

--- a/helm/gcp-compute-persistent-disk-csi-driver/templates/v1_serviceaccount_csi-gce-pd-node-sa.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/templates/v1_serviceaccount_csi-gce-pd-node-sa.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    giantswarm.io/gcp-workload-identity-pool-id: '{{.Values.gcpProject}}.svc.id.goog'
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/gcp-compute-persistent-disk-csi-driver/values.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/values.yaml
@@ -26,6 +26,6 @@ image:
     name: quay.io/giantswarm/csi-snapshotter
     tag: v4.0.1
 
-gcpProject: ""
+workloadIdentityPoolID: ""
 gcpServiceAccount: ""
-gkeHubMembershiName: ""
+gcpIdentityProvider: ""

--- a/helm/gcp-compute-persistent-disk-csi-driver/values.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/values.yaml
@@ -12,7 +12,7 @@ image:
     tag: v2.5.0
   driver:
     name: quay.io/giantswarm/gcp-compute-persistent-disk-csi-driver
-    tag: v1.7.1
+    tag: 7a126c25-gs1
   provisioner:
     name: quay.io/giantswarm/csi-provisioner
     tag: v3.1.0
@@ -27,3 +27,5 @@ image:
     tag: v4.0.1
 
 gcpProject: ""
+gcpServiceAccount: ""
+gkeHubMembershiName: ""

--- a/helm/gcp-compute-persistent-disk-csi-driver/values.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/values.yaml
@@ -12,7 +12,7 @@ image:
     tag: v2.5.0
   driver:
     name: quay.io/giantswarm/gcp-compute-persistent-disk-csi-driver
-    tag: 7a126c25-gs1
+    tag: v1.7.1
   provisioner:
     name: quay.io/giantswarm/csi-provisioner
     tag: v3.1.0

--- a/helm/gcp-compute-persistent-disk-csi-driver/values.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/values.yaml
@@ -26,6 +26,6 @@ image:
     name: quay.io/giantswarm/csi-snapshotter
     tag: v4.0.1
 
-workloadIdentityPoolID: ""
+gcpWorkloadIdentityPoolID: ""
 gcpServiceAccount: ""
 gcpIdentityProvider: ""

--- a/helm/gcp-compute-persistent-disk-csi-driver/values.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/values.yaml
@@ -26,14 +26,4 @@ image:
     name: quay.io/giantswarm/csi-snapshotter
     tag: v4.0.1
 
-# gcpServiceAccount
-# The GCP Service Account ID to use when running on gcp, using workload identity for authentication.
-gcpServiceAccount: ""
-
-# gcpWorkloadIdentityPoolID
-# The workload identity pool ID for the cluster where the app will run. It's of the form '$gcpProject.svc.id.goog'.
-gcpWorkloadIdentityPoolID: ""
-
-# gcpIdentityProvider
-# The workload identity identity provider for the cluster where the app will run.
-gcpIdentityProvider: ""
+gcpProject: ""

--- a/helm/gcp-compute-persistent-disk-csi-driver/values.yaml
+++ b/helm/gcp-compute-persistent-disk-csi-driver/values.yaml
@@ -26,6 +26,14 @@ image:
     name: quay.io/giantswarm/csi-snapshotter
     tag: v4.0.1
 
-gcpWorkloadIdentityPoolID: ""
+# gcpServiceAccount
+# The GCP Service Account ID to use when running on gcp, using workload identity for authentication.
 gcpServiceAccount: ""
+
+# gcpWorkloadIdentityPoolID
+# The workload identity pool ID for the cluster where the app will run. It's of the form '$gcpProject.svc.id.goog'.
+gcpWorkloadIdentityPoolID: ""
+
+# gcpIdentityProvider
+# The workload identity identity provider for the cluster where the app will run.
 gcpIdentityProvider: ""


### PR DESCRIPTION
* Use `7a126c25-gs1` image tag. This tag is custom built from our fork.
  It contains updated dependencies which make using workload identity
  possible. This tag should be replaced when there is a new image of
  `gcp-compute-persistent-disk-csi-driver`
* Allow `projected` volume in PSP. The workload identity webhook mounts
  a projected volume with the JSON credentials and Kubernetes
  ServiceAccount token.
* Add workload-identity annotations and helm values

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
